### PR TITLE
feat(config): disable import/no-cycle

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = {
     // eslint-plugin-import
     "import/first": 1,
     "import/newline-after-import": 1,
-    "import/no-cycle": 2,
+    "import/no-cycle": 0,
     "import/no-duplicates": 1,
     "import/no-unresolved": 2,
 


### PR DESCRIPTION
Resolve issue with dependency cycles.

We want to avoid @typescript-eslint/parser parsing node_modules/react-native/index.js.

As a bonus, this task was comparatively computationally expensive.

It's not possible too ignore parsing node_modules/react-native/index.js via ESLint ignorePatterns.

---

Repro steps

- Setup: https://github.com/react-native-community/react-native-template-typescript (0.62.2)
- Add: https://github.com/gabts/eslint-config-react-native-typescript
- Even disable .eslintrc extends rule '@react-native-community' just to be sure
- `yarn lint`

```
Error while parsing /my-project/node_modules/react-native/index.js
Line 13, column 32: ';' expected.
`parseForESLint` from parser `/my-project/node_modules/@typescript-eslint/parser/dist/parser.js` is invalid and will just be ignored.
```